### PR TITLE
Fix bug with negative column number in range vscode

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
         if (!["c", "cpp"].includes(document.languageId)) {
             // Not a C/C++ file, skip
             return;
-            
+
         }
 
         // Check if the document is visible in any editor
@@ -148,7 +148,7 @@ async function runCppcheck(
         while ((match = regex.exec(allOutput)) !== null) {
             const [, file, lineStr, colStr, severityStr, message] = match;
             const line = parseInt(lineStr, 10) - 1;
-            const col = parseInt(colStr, 10) - 1;
+            const col = parseInt(colStr, 10);
             const diagSeverity = parseSeverity(severityStr);
 
             // Filter out if severity is less than our minimum
@@ -163,7 +163,7 @@ async function runCppcheck(
 
             const range = new vscode.Range(line, col, line, col);
             const diagnostic = new vscode.Diagnostic(range, message, diagSeverity);
-            diagnostic.code = standard !== "<none>" ? standard : "";; 
+            diagnostic.code = standard !== "<none>" ? standard : "";;
 
             diagnostics.push(diagnostic);
         }


### PR DESCRIPTION
Ubuntu 24.04
cppcheck 2.13.0

Messages from cppcheck: `file.cpp:1:0: ...`

Rows start at 1 and columns at 0. This leads to an error when creating a range in `vscode.Range`