### PR TITLE
Add ability working cppcheck on project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,21 @@
 # Change Log
 
+## [1.3.2] - 2025-07-14
+- Added `cppcheck-lite.project` setting to specify passing file path to `cppcheck` when work with project.
+
 ## [1.3.1] - 2025-07-11
 - Fix bug with negative column number in range vscode ([#2](https://github.com/JustusRijke/Cppcheck-Lite/pull/2))
 
 ## [1.3.0] - 2025-05-28
 - Added <none> option to `cppcheck-lite.standard`, allowing users to specify it manually via `cppcheck-lite.arguments` or let `cppcheck` use its default setting.
-- Improved Windows compatibility by quoting paths and normalizing backslashes in executable and file paths. 
+- Improved Windows compatibility by quoting paths and normalizing backslashes in executable and file paths.
 
 ## [1.2.1] - 2025-02-08
 - **FIX** Ignore background file openings (e.g., during symbol renaming) to prevent unnecessary Cppcheck runs and clutter in the Problems tab.
 
 ## [1.2.0] - 2025-02-02
 - Added `cppcheck-lite.path` setting to specify a custom path to the `cppcheck` executable.
-- Improved error handling to display a message if `cppcheck` is not found or cannot be run.  
+- Improved error handling to display a message if `cppcheck` is not found or cannot be run.
 
 ## [1.1.0] - 2025-02-02
 - Added "Code" field showing the applied C/C++ standard to items in the Problems panel.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "analysis",
     "diagnostic",
     "linter"
-  ],  
+  ],
   "categories": [
     "Linters"
   ],
@@ -35,7 +35,7 @@
   "contributes": {
     "configuration": [
       {
-        "title": "Cppcheck Lite (General)",
+        "title": "General",
         "order": 1,
         "properties": {
           "cppcheck-lite.enable": {
@@ -72,7 +72,7 @@
         }
       },
       {
-        "title": "Cppcheck Lite (Advanced)",
+        "title": "Advanced",
         "order": 2,
         "properties": {
           "cppcheck-lite.path": {
@@ -84,6 +84,11 @@
             "type": "string",
             "default": "",
             "description": "Additional command line arguments for cppcheck."
+          },
+          "cppcheck-lite.project": {
+            "type": "boolean",
+            "default": false,
+            "description": "Indicates using project configuration."
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,8 @@ export function activate(context: vscode.ExtensionContext) {
     const diagnosticCollection = vscode.languages.createDiagnosticCollection("Cppcheck Lite");
     context.subscriptions.push(diagnosticCollection);
 
+    const outputChannel = vscode.window.createOutputChannel('Cppcheck Lite', 'cppcheck-lite');
+
     async function handleDocument(document: vscode.TextDocument) {
         // Only process C/C++ files.
         if (!["c", "cpp"].includes(document.languageId)) {
@@ -64,6 +66,7 @@ export function activate(context: vscode.ExtensionContext) {
         const standard = config.get<string>("cppcheck-lite.standard", "c++17");
         const userPath = config.get<string>("cppcheck-lite.path")?.trim() || "";
         const commandPath = userPath ? userPath : "cppcheck";
+        const project = config.get<boolean>("cppcheck-lite.project", false);
 
         // If disabled, clear any existing diagnostics for this doc.
         if (!isEnabled) {
@@ -88,7 +91,9 @@ export function activate(context: vscode.ExtensionContext) {
             extraArgs,
             minSevString,
             standard,
-            diagnosticCollection
+            project,
+            diagnosticCollection,
+            outputChannel
         );
     }
 
@@ -118,26 +123,35 @@ async function runCppcheck(
     extraArgs: string,
     minSevString: string,
     standard: string,
-    diagnosticCollection: vscode.DiagnosticCollection
+    project: boolean,
+    diagnosticCollection: vscode.DiagnosticCollection,
+    outputChannel: vscode.OutputChannel
 ): Promise<void> {
     // Clear existing diagnostics for this file
     diagnosticCollection.delete(document.uri);
 
-    const filePath = document.fileName;
+    const filePath = document.fileName.replace(/\\/g, '/').trim();
     const minSevNum = parseMinSeverity(minSevString);
-    const standardArg = standard !== "<none>" ? `--std=${standard}` : "";
-    const command = `"${commandPath}" ${standardArg} ${extraArgs} "${filePath.replace(/\\/g, '/')}"`.trim();
 
-    console.log("Cppcheck command:", command);
+    const standardArg = standard !== "<none>" ? `--std=${standard}` : "";
+    const filePathArg = project ? `--file-filter=${filePath}` : `${filePath}`;
+
+    const command = `"${commandPath}" ${standardArg} ${extraArgs} ${filePathArg}`;
+
+    console.log(`Cppcheck command: ${command}`);
+    outputChannel.appendLine(`Cppcheck command: ${command}`);
 
     cp.exec(command, (error, stdout, stderr) => {
         if (error) {
             vscode.window.showErrorMessage(`Cppcheck Lite: ${error.message}`);
+            outputChannel.appendLine(`Error: ${error.message}`);
             return;
         }
 
         const allOutput = stdout + "\n" + stderr;
         const diagnostics: vscode.Diagnostic[] = [];
+
+        outputChannel.appendLine(`Output: ${allOutput}`);
 
         // Example lines we might see:
         //   file.cpp:6:1: error: Something [id]


### PR DESCRIPTION
Add ability cppcheck work with project.

Now you can pass to arguments `--project=<path>/compile_commands.json` (for example with cmake), set checker `cppcheck-lite.project` on `true` and it will work.